### PR TITLE
Add Bake Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ You can set a custom serializer (class name or object) via `serializer` view bui
 ```php
 $this->viewBuilder()->setOption('serializer', new CustomSerializer());
 ```
+## Baking Transformers
+
+To bake transformers you must include the plugin in your src/Application.php file. Add the following to your bootstrap method:
+
+```php
+$this->addPlugin('FractalTransformerView');
+```
+
+You must also have the [cakephp/bake](https://packagist.org/packages/cakephp/bake) composer package installed.
+
+You can now run `bin/cake bake transformer YOUR_MODEL` to create transformers.
 
 ## Bugs & Feedback
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "league/fractal": "^0.20.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0",
+        "cakephp/bake": "^2.9"
     },
     "autoload": {
         "psr-4": {
@@ -29,5 +30,8 @@
             "FractalTransformerView\\Test\\": "tests",
             "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
         }
+    },
+    "suggest": {
+        "cakephp/bake": "Required to generate transformers."
     }
 }

--- a/src/Command/BakeTransformerCommand.php
+++ b/src/Command/BakeTransformerCommand.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace FractalTransformerView\Command;
+
+use Bake\Command\SimpleBakeCommand;
+use Cake\Console\Arguments;
+use Cake\Database\Exception\DatabaseException;
+use Cake\Utility\Inflector;
+
+class BakeTransformerCommand extends SimpleBakeCommand
+{
+    /**
+     * The pathFragment appended to the plugin/app path.
+     *
+     * @var string
+     */
+    protected $pathFragment = 'Model/Transformer/';
+
+    /**
+     * Get the generated object's name.
+     *
+     * @return string
+     */
+    public function name(): string
+    {
+        return 'transformer';
+    }
+
+    /**
+     * Get the generated object's filename without the leading path.
+     *
+     * @param string $name The name of the object being generated
+     * @return string
+     */
+    public function fileName(string $name): string
+    {
+        return $name . 'Transformer.php';
+    }
+
+    /**
+     * Get the template name.
+     *
+     * @return string
+     */
+    public function template(): string
+    {
+        return 'FractalTransformerView.transformer';
+    }
+
+    /**
+     * Get template data.
+     *
+     * @param \Cake\Console\Arguments $arguments The arguments for the command
+     * @return array
+     * @phpstan-return array<string, mixed>
+     */
+    public function templateData(Arguments $arguments): array
+    {
+        $parentData = parent::templateData($arguments);
+        $data = [];
+
+        $plugin = $this->plugin;
+        if ($plugin) {
+            $plugin .= '.';
+        }
+
+        $modelName = Inflector::pluralize($arguments->getArgument('name'));
+        if ($this->getTableLocator()->exists($plugin . $modelName)) {
+            $modelObj = $this->getTableLocator()->get($plugin . $modelName);
+        } else {
+            $modelObj = $this->getTableLocator()->get($plugin . $modelName, [
+                'connectionName' => $this->connection,
+            ]);
+        }
+
+        try {
+            $schema = $modelObj->getSchema();
+            $data['columns'] = $schema->columns();
+            $data['entityClass'] = $modelObj->getEntityClass();
+            $data['entityName'] = substr($data['entityClass'], strrpos($data['entityClass'], '\\') + 1);
+        } catch (DatabaseException) {
+            $data['columns'] = ['id'];
+            $data['entityClass'] = 'Cake\\ORM\\Entity';
+            $data['entityName'] = 'Entity';
+        }
+        $data['entityVariable'] = Inflector::variable($data['entityName']);
+
+        return array_merge($parentData, $data);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,10 +3,12 @@ declare(strict_types=1);
 
 namespace FractalTransformerView;
 
+use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
+use FractalTransformerView\Command\BakeTransformerCommand;
 
 /**
  * Plugin for FractalTransformerView
@@ -60,5 +62,20 @@ class Plugin extends BasePlugin
         // Add your middlewares here
 
         return $middlewareQueue;
+    }
+
+    /**
+     * Add console commands for the plugin.
+     *
+     * @param \Cake\Console\CommandCollection $commands The command collection to update
+     * @return \Cake\Console\CommandCollection
+     */
+    public function console(CommandCollection $commands): CommandCollection
+    {
+        if (class_exists('Bake\Command\SimpleBakeCommand')) {
+            $commands->add('bake transformer', BakeTransformerCommand::class);
+        }
+
+        return $commands;
     }
 }

--- a/templates/bake/transformer.twig
+++ b/templates/bake/transformer.twig
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace {{ namespace }}\Model\Transformer;
+
+use {{ entityClass }};
+use League\Fractal\TransformerAbstract;
+
+class {{ name }}Transformer extends TransformerAbstract
+{
+    /**
+     * Creates a response item for each instance
+     *
+     * @return array the transformed entity
+     */
+    public function transform({{ entityName }} ${{ entityVariable }})
+    {
+        return [
+{% for column in columns %}
+            '{{ column }}' => ${{ entityVariable }}->{{ column }},
+{% endfor %}
+        ];
+    }
+}


### PR DESCRIPTION
Add the ability to bake transformers. Transforms all fields in the table by default. This will save the user a lot of hassle having to figure out which fields are available.